### PR TITLE
Category rework2

### DIFF
--- a/src/main/java/com/data/dataxer/controllers/CategoryController.java
+++ b/src/main/java/com/data/dataxer/controllers/CategoryController.java
@@ -41,7 +41,7 @@ public class CategoryController {
     @GetMapping("/updateTree")
     public void updateTree(@RequestParam(value = "id", defaultValue = "-1") Long parentId,
                            @RequestBody CategoryDTO categoryDTO) {
-        categoryService.updateTree(parentId, categoryMapper.toCategory(categoryDTO));
+        categoryService.updateTree(parentId, categoryMapper.toCategory(categoryDTO), categoryDTO.getId());
     }
 
     @GetMapping("/children")

--- a/src/main/java/com/data/dataxer/controllers/CategoryController.java
+++ b/src/main/java/com/data/dataxer/controllers/CategoryController.java
@@ -21,6 +21,12 @@ public class CategoryController {
         this.categoryMapper = categoryMapper;
     }
 
+    @PostMapping("/store")
+    public void store(@RequestBody CategoryDTO categoryDTO,
+                      @RequestParam(value = "parentId", defaultValue = "0") Long parentId) {
+        this.categoryService.store(categoryMapper.toCategory(categoryDTO), parentId);
+    }
+
     @GetMapping("/all")
     public ResponseEntity<List<CategoryDTO>> all() {
         return ResponseEntity.ok(categoryMapper.toCategoryDTOs(categoryService.all()));
@@ -32,9 +38,15 @@ public class CategoryController {
         return ResponseEntity.ok(categoryMapper.toCategoryNestedDTOs(categoryService.nested()));
     }
 
-    @PostMapping("/store")
-    public ResponseEntity<CategoryDTO> store(@RequestBody CategoryDTO categoryDTO) {
-        return ResponseEntity.ok(categoryMapper.toCategoryDTO(this.categoryService.store(categoryMapper.toCategory(categoryDTO))));
+    @GetMapping("/updateTree")
+    public void updateTree(@RequestParam(value = "id", defaultValue = "-1") Long parentId,
+                           @RequestBody CategoryDTO categoryDTO) {
+        categoryService.updateTree(parentId, categoryMapper.toCategory(categoryDTO));
+    }
+
+    @GetMapping("/children")
+    public ResponseEntity<List<CategoryDTO>> getChildren(@RequestParam(value = "id") Long id) {
+        return ResponseEntity.ok(this.categoryMapper.toCategoryDTOs(this.categoryService.getChildren(id)));
     }
 
     @GetMapping("/{id}")
@@ -46,4 +58,5 @@ public class CategoryController {
     public void destroy(@PathVariable Long id) {
         categoryService.delete(id);
     }
+
 }

--- a/src/main/java/com/data/dataxer/mappers/ItemMapper.java
+++ b/src/main/java/com/data/dataxer/mappers/ItemMapper.java
@@ -4,8 +4,10 @@ import com.data.dataxer.models.domain.Item;
 import com.data.dataxer.models.domain.ItemPrice;
 import com.data.dataxer.models.dto.ItemDTO;
 import com.data.dataxer.models.dto.ItemPriceDTO;
-import org.mapstruct.*;
-import org.mapstruct.factory.Mappers;
+import org.mapstruct.IterableMapping;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.Named;
 
 import java.util.List;
 
@@ -17,7 +19,6 @@ public interface ItemMapper {
     //@Mapping(target = "category.parent", ignore = true)
     ItemDTO itemToItemDto(Item item);
 
-    @Mapping(target = "category.parent", ignore = true)
     Item toItem(ItemDTO itemDTO);
 
     @Named(value = "itemToItemDTOWithPrice")

--- a/src/main/java/com/data/dataxer/models/domain/Category.java
+++ b/src/main/java/com/data/dataxer/models/domain/Category.java
@@ -2,7 +2,6 @@ package com.data.dataxer.models.domain;
 
 import com.data.dataxer.securityContextUtils.SecurityUtils;
 import com.fasterxml.jackson.annotation.JsonIgnore;
-import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.Setter;
 import org.hibernate.annotations.CreationTimestamp;
@@ -12,10 +11,7 @@ import org.springframework.security.core.context.SecurityContextHolder;
 import works.hacker.mptt.classic.MpttEntity;
 
 import javax.persistence.*;
-import javax.validation.constraints.NotNull;
 import java.time.LocalDateTime;
-import java.util.ArrayList;
-import java.util.List;
 
 @Entity
 @Getter
@@ -31,10 +27,7 @@ public class Category extends MpttEntity {
         super(name);
     }
 
-    @JsonIgnore
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "parent_id")
-    private Category parent;
+    private Integer position;
 
     @JsonIgnore
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/com/data/dataxer/models/dto/CategoryDTO.java
+++ b/src/main/java/com/data/dataxer/models/dto/CategoryDTO.java
@@ -9,4 +9,9 @@ import lombok.Setter;
 public class CategoryDTO {
     private Long id;
     private String name;
+    private Integer position;
+    //potrebujeme aby sme vedeli vyhladavat pomocou integrovanych metod
+    private Long treeId;
+    private Long lft;
+    private Long rgt;
 }

--- a/src/main/java/com/data/dataxer/repositories/CategoryRepository.java
+++ b/src/main/java/com/data/dataxer/repositories/CategoryRepository.java
@@ -16,7 +16,7 @@ public interface CategoryRepository extends JpaRepository<Category, Long>, Categ
     @Query("SELECT c FROM Category c WHERE c.company.id = ?1")
     List<Category> findAllByCompanyId(Long companyId);
 
-    @Query("SELECT c FROM Category c WHERE c.company.id = ?1 AND c.parent IS NULL")
-    List<Category> findAllByCompanyIdAndParentIsNull(Long companyId);
+    @Query("SELECT c FROM Category c WHERE c.company.id = ?1 AND c.depth = 0")
+    List<Category> findAllByCompanyIdAndDepth(Long companyId);
 
 }

--- a/src/main/java/com/data/dataxer/repositories/CategoryRepository.java
+++ b/src/main/java/com/data/dataxer/repositories/CategoryRepository.java
@@ -2,7 +2,9 @@ package com.data.dataxer.repositories;
 
 import com.data.dataxer.models.domain.Category;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
@@ -17,6 +19,16 @@ public interface CategoryRepository extends JpaRepository<Category, Long>, Categ
     List<Category> findAllByCompanyId(Long companyId);
 
     @Query("SELECT c FROM Category c WHERE c.company.id = ?1 AND c.depth = 0")
-    List<Category> findAllByCompanyIdAndDepth(Long companyId);
+    List<Category> findAllByCompanyIdAndDepthOrderByPositionAsc(Long companyId);
+
+    @Transactional
+    @Modifying
+    @Query("UPDATE Category c SET c.position = c.position + ?2 WHERE c.id IN ?1 AND c.company.id = ?3")
+    void updateCategoriesPosition(List<Long> ids, int value, Long companyId);
+
+    @Transactional
+    @Modifying
+    @Query("UPDATE Category c SET c.position = ?2 WHERE c.id = ?1 AND c.company.id = ?3")
+    void setCategoryPosition(Long id, Integer value, Long companyId);
 
 }

--- a/src/main/java/com/data/dataxer/services/CategoryService.java
+++ b/src/main/java/com/data/dataxer/services/CategoryService.java
@@ -16,7 +16,7 @@ public interface CategoryService {
 
     List<Category> getChildren(Long parentId);
 
-    void updateTree(Long parentId, Category category);
+    void updateTree(Long parentId, Category category, Long categoryId);
 
     void delete(Long id);
 }

--- a/src/main/java/com/data/dataxer/services/CategoryService.java
+++ b/src/main/java/com/data/dataxer/services/CategoryService.java
@@ -6,7 +6,7 @@ import java.util.List;
 
 public interface CategoryService {
 
-    Category store(Category category);
+    void store(Category category, Long parentId);
 
     Category getById(Long id);
 
@@ -14,7 +14,9 @@ public interface CategoryService {
 
     List<Category> nested();
 
-    /*void updateTree(List<Category> categories, Category category);*/
+    List<Category> getChildren(Long parentId);
+
+    void updateTree(Long parentId, Category category);
 
     void delete(Long id);
 }


### PR DESCRIPTION
- ak vkladame novy node tak sa vsetkym surodencom s poziciou >= ako novy node zmeni pozicia o +1
- ak len menime poziciu (sucasny parent je ten isty ako novy => cez param parentId) tak sa pozicia meni v zavislosti ci idem s poziciou smerom do lava alebo do prava a len pre suroncom co maju poziciu v ramci interalu zmeny
- ak ideme premiesnit do ineho parenta sa zmeni zmeni poziciovanie pre vsetkych starych surodencom a zaroben aj vsetkym novym ktory maju poziciu >= ako presuvaneho nodu
- vsade kde sa vracia list kategorii su zoradene podla position ak to dava zmysel => zoznam childov, zoznam rootov
- testovane s poziciovanim od 0 ale teoreticky by to malo fungovat aj od 1 alebo ineho cisla
- ak sa meni len pozica metoda updateTree potrebuje aby param parentId bol ten isty ako sucasny parent
- ak sa node presuva na poziciu noveho roota parentId nemusi byt vobec => pouzije sa def hodnota -1 co znaci ze to bude novy root, pripadne moze byt param akekolvek cislo <= 0